### PR TITLE
Respect defaults

### DIFF
--- a/health.js
+++ b/health.js
@@ -11,7 +11,7 @@ const protoDefinition = protoLoader.loadSync(protoPath, {
   keepCase: false,
   longs: String,
   enums: String,
-  defaults: false,
+  defaults: true,
   oneofs: true,
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -28,9 +28,7 @@ describe('testing health check for gRPC server', () => {
   });
 
   it('should say an enabled service is SERVING', (done) => {
-    const request = {
-      service: '',
-    };
+    const request = {};
 
     client.check(request, (err, response) => {
       assert.ifError(err);


### PR DESCRIPTION
Actually, the server status check is failing because the check for the `service` `''` returns `Not Found` and it's not possible to force it to be empty like e.g. with : `grpcurl -proto healthcheck.proto -d '{"service": ""}' -plaintext localhost:3000 grpc.health.v1.Health/Check`